### PR TITLE
Refactored result-gathering process

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,31 @@ plot_multiple_datasets(df_results, metric_name="Avg ACC (Validation Test)", id_c
 
 ![](multimedia/dataset_batch.png)
 
+## How is the data used?
+
+By default, Hundred Hammers will split the data into train and test.
+If the user defines a normalization procedure (through the `input_transform` parameter), then 
+normalization will be fitted to the training data and applied to both partitions.
+Next, if the user enabled hyperparameter optimization, the training data is used 
+to fit the hyperparameters of each model, through a Grid Search with `n_folds_tune` folds.
+The model is then trained on the training data and evaluated on both partitions 
+to produce the **train** and **test** results.
+
+As is standard in ML, the training data is also used in a cross-validation fashion,
+according to the cross-validator passed by the user (through the `cross_validator` parameter).
+The user-defined metrics are then average over the cross-validation folds to produced 
+both **validation train** and **validation test** results.
+
+Two DataFrames are provided to the user: a *full report* (`hh._full_report`) with the results for each 
+model, seed, and cross-validation fold; and a *summary report* (`hh._report)`with the average results
+for each model. 
+
+Furthermore, with flexibility in mind, Hundred Hammers also allows the user to define 
+how many seeds will be tested and averaged for both training and validation splitting. 
+This is done through the `n_train_evals` and `n_val_evals` parameters, which are both `1`
+by default (i.e. a single train/test split is done, and inside the training data, a 
+single cross-validation scheme is run).
+
+Since the usage of data is key, we provide below an image to illustrate how the data is used:
+
+![](multimedia/data_flow.png)

--- a/src/hundred_hammers/base.py
+++ b/src/hundred_hammers/base.py
@@ -47,9 +47,9 @@ class HundredHammersBase:
     :param cross_validator: Cross Validator to use in the evaluation.
     :param cross_validator_params: Parameters for the Cross Validator.
     :param test_size: Percentage of the dataset to use for testing.
-    :param n_folds_tune: Number of Cross Validation folds in grid search.
     :param n_train_evals: Number of times to vary the training/test separation seed.
     :param n_val_evals: Number of times to vary the cross-validation seed.
+    :param n_folds_tune: Number of Cross Validation folds to use in hyperparameter optimization grid search.
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
 
@@ -62,9 +62,9 @@ class HundredHammersBase:
         cross_validator: callable = None,
         cross_validator_params: dict = None,
         test_size: float = 0.2,
-        n_folds_tune: int = 5,
         n_train_evals: int = 1,
-        n_val_evals: int = 10,
+        n_val_evals: int = 1,
+        n_folds_tune: int = 5,
         show_progress_bar: bool = True,
         seed_strategy: str = "sequential",
     ):

--- a/src/hundred_hammers/base.py
+++ b/src/hundred_hammers/base.py
@@ -49,7 +49,7 @@ class HundredHammersBase:
     :param test_size: Percentage of the dataset to use for testing.
     :param n_folds_tune: Number of Cross Validation folds in grid search.
     :param n_train_evals: Number of times to vary the training/test separation seed.
-    :param n_cv_evals: Number of times to vary the cross-validation seed.
+    :param n_val_evals: Number of times to vary the cross-validation seed.
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
 
@@ -64,7 +64,7 @@ class HundredHammersBase:
         test_size: float = 0.2,
         n_folds_tune: int = 5,
         n_train_evals: int = 1,
-        n_cv_evals: int = 10,
+        n_val_evals: int = 10,
         show_progress_bar: bool = True,
         seed_strategy: str = "sequential",
     ):
@@ -81,7 +81,7 @@ class HundredHammersBase:
         self.test_size = test_size
         self.n_folds_tune = n_folds_tune
         self.n_train_evals = n_train_evals
-        self.n_cv_evals = n_cv_evals
+        self.n_val_evals = n_val_evals
         self.show_progress_bar = show_progress_bar
         self.seed_strategy = seed_strategy
 
@@ -301,7 +301,7 @@ class HundredHammersBase:
         results = []
         for i, (name, model, _) in enumerate(tqdm(models, desc="Evaluating models...", disable=not self.show_progress_bar)):
             hh_logger.info(f"Running model [{i + 1}/{len(models)}]: {name}")
-            res_val_train, res_val_test = self._evaluate_model_cv_multiple_seeds(X_train, y_train, model, n_evals=self.n_cv_evals)
+            res_val_train, res_val_test = self._evaluate_model_cv_multiple_seeds(X_train, y_train, model, n_evals=self.n_val_evals)
 
             trained_model = copy(model)
             with warnings.catch_warnings():

--- a/src/hundred_hammers/base.py
+++ b/src/hundred_hammers/base.py
@@ -48,10 +48,9 @@ class HundredHammersBase:
     :param cross_validator_params: Parameters for the Cross Validator.
     :param test_size: Percentage of the dataset to use for testing.
     :param n_folds_tune: Number of Cross Validation folds in grid search.
-    :param n_train_evals: Number of times to repeat the training of the models.
-    :param n_cv_evals: Number of times to repeat the Cross Validation.
+    :param n_train_evals: Number of times to vary the training/test separation seed.
+    :param n_cv_evals: Number of times to vary the cross-validation seed.
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
-    :param seed_train_test: Seed used to split the dataset into train and test.
     """
 
     def __init__(

--- a/src/hundred_hammers/base.py
+++ b/src/hundred_hammers/base.py
@@ -235,8 +235,9 @@ class HundredHammersBase:
 
         res_cols = [f"{m} / {v}" for (m, _, _) in self.metrics for v in ["Validation Train", "Validation Test", "Train", "Test"]]
         report = full_report.groupby(["Model"]).agg({col: ["mean", "std"] for col in res_cols}).reset_index()
-        report.columns = report.columns.to_flat_index().str.join(' / ')
+        report.columns = report.columns.to_flat_index().str.join(" / ")
         report.columns = report.columns.str.replace("mean", "Mean").str.replace("std", "Std")
+        report.columns = report.columns.str.replace("Model / ", "Model")
 
         # Store data in the object's attributes
         self._report = report

--- a/src/hundred_hammers/base.py
+++ b/src/hundred_hammers/base.py
@@ -114,6 +114,20 @@ class HundredHammersBase:
         self._trained_models = self.models
 
     @property
+    def full_report(self) -> pd.DataFrame:
+        """
+        Pandas dataframe reflecting the results of the last evaluation of the models with extra information.
+
+        :return: Dataframe with the performance of each of the models.
+        """
+
+        if self._full_report.empty:
+            hh_logger.warning("No reports available. Use the `evaluate` method to generate the full report.")
+
+        return self._full_report
+        
+
+    @property
     def report(self) -> pd.DataFrame:
         """
         Pandas dataframe reflecting the results of the last evaluation of the models.
@@ -199,11 +213,11 @@ class HundredHammersBase:
                 new_models = deepcopy(self.models)
 
             # Evaluate models
-            _res = self._evaluate_models(X_norm_train, y_train, X_norm_test, y_test, new_models)
-            model_names, trained_models, results = zip(*_res)
+            model_tuples = self._evaluate_models(X_norm_train, y_train, X_norm_test, y_test, new_models)
+            model_names, trained_models, results = zip(*model_tuples)
 
             # Add results to dataframe
-            for model_name, trained_model, res in zip(model_names, trained_models, results):
+            for model_name, trained_model, res in model_tuples:
                 results_val_train, results_val_test, result_train, result_test = res
                 for res_val_train, res_val_test in zip(results_val_train, results_val_test):
                     val_seed = res_val_train[0]

--- a/src/hundred_hammers/classifier.py
+++ b/src/hundred_hammers/classifier.py
@@ -48,18 +48,18 @@ class HundredHammersClassifier(HundredHammersBase):
             metrics = copy(DEFAULT_CLASSIFICATION_METRICS)
 
         super().__init__(
-            models,
-            metrics,
-            eval_metric,
-            input_transform,
-            cross_validator,
-            cross_validator_params,
-            test_size,
-            n_folds_tune,
-            n_train_evals,
-            n_val_evals,
-            show_progress_bar,
-            seed_strategy,
+            models=models,
+            metrics=metrics,
+            eval_metric=eval_metric,
+            input_transform=input_transform,
+            cross_validator=cross_validator,
+            cross_validator_params=cross_validator_params,
+            test_size=test_size,
+            n_train_evals=n_train_evals,
+            n_val_evals=n_val_evals,
+            n_folds_tune=n_folds_tune,
+            show_progress_bar=show_progress_bar,
+            seed_strategy=seed_strategy,
         )
 
     def _stratify_array(self, y):

--- a/src/hundred_hammers/classifier.py
+++ b/src/hundred_hammers/classifier.py
@@ -19,9 +19,9 @@ class HundredHammersClassifier(HundredHammersBase):
     :param cross_validator: Cross Validator to use in the evaluation (default KFold)
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
-    :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
     :param n_train_evals: Number of times to vary the training/test separation seed.
     :param n_val_evals: Number of times to vary the cross-validation seed.
+    :param n_folds_tune: Number of Cross Validation folds to use in hyperparameter optimization grid search (default 5)
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
@@ -35,9 +35,9 @@ class HundredHammersClassifier(HundredHammersBase):
         cross_validator=StratifiedKFold,
         cross_validator_params={"shuffle": True, "n_splits": 5},
         test_size=0.2,
-        n_folds_tune=5,
         n_train_evals=1,
-        n_val_evals=10,
+        n_val_evals=1,
+        n_folds_tune=5,
         show_progress_bar=False,
         seed_strategy="sequential",
     ):

--- a/src/hundred_hammers/classifier.py
+++ b/src/hundred_hammers/classifier.py
@@ -21,7 +21,7 @@ class HundredHammersClassifier(HundredHammersBase):
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
     :param n_train_evals: Number of times to vary the training/test separation seed.
-    :param n_cv_evals: Number of times to vary the cross-validation seed.
+    :param n_val_evals: Number of times to vary the cross-validation seed.
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
@@ -37,7 +37,7 @@ class HundredHammersClassifier(HundredHammersBase):
         test_size=0.2,
         n_folds_tune=5,
         n_train_evals=1,
-        n_cv_evals=10,
+        n_val_evals=10,
         show_progress_bar=False,
         seed_strategy="sequential",
     ):
@@ -57,7 +57,7 @@ class HundredHammersClassifier(HundredHammersBase):
             test_size,
             n_folds_tune,
             n_train_evals,
-            n_cv_evals,
+            n_val_evals,
             show_progress_bar,
             seed_strategy,
         )

--- a/src/hundred_hammers/classifier.py
+++ b/src/hundred_hammers/classifier.py
@@ -20,9 +20,9 @@ class HundredHammersClassifier(HundredHammersBase):
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
-    :param n_evals: Number of times to repeat the training of the models (default 10)
+    :param n_cv_evals: Number of times to repeat the training of the models (default 10)
     :param show_progress_bar: Show progress bar in the evaluation (default False)
-    :param seed_cv_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
+    :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     :param seed_train_test: Seed used to split the dataset into train and test (default 0)
     """
 
@@ -36,10 +36,10 @@ class HundredHammersClassifier(HundredHammersBase):
         cross_validator_params={"shuffle": True, "n_splits": 5},
         test_size=0.2,
         n_folds_tune=5,
-        n_evals=10,
+        n_train_evals=1,
+        n_cv_evals=10,
         show_progress_bar=False,
-        seed_cv_strategy="sequential",
-        seed_train_test=0,
+        seed_strategy="sequential",
     ):
         if models is None:
             models = deepcopy(DEFAULT_CLASSIFICATION_MODELS)
@@ -56,10 +56,10 @@ class HundredHammersClassifier(HundredHammersBase):
             cross_validator_params,
             test_size,
             n_folds_tune,
-            n_evals,
+            n_train_evals,
+            n_cv_evals,
             show_progress_bar,
-            seed_cv_strategy,
-            seed_train_test,
+            seed_strategy,
         )
 
     def _stratify_array(self, y):

--- a/src/hundred_hammers/classifier.py
+++ b/src/hundred_hammers/classifier.py
@@ -20,10 +20,10 @@ class HundredHammersClassifier(HundredHammersBase):
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
-    :param n_cv_evals: Number of times to repeat the training of the models (default 10)
+    :param n_train_evals: Number of times to vary the training/test separation seed.
+    :param n_cv_evals: Number of times to vary the cross-validation seed.
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
-    :param seed_train_test: Seed used to split the dataset into train and test (default 0)
     """
 
     def __init__(

--- a/src/hundred_hammers/plots.py
+++ b/src/hundred_hammers/plots.py
@@ -40,7 +40,7 @@ def plot_confusion_matrix(X, y, model, class_dict, title="", test_size=0.2, seed
 
     # Plotting
     sns.set_style("ticks")
-    fig, axs = plt.subplots(2, 2, figsize=(10, 10))
+    fig, axs = plt.subplots(2, 2, figsize=(8, 8))
     fig.patch.set_facecolor("lightgrey")
 
     for i, md in enumerate([model, DummyClassifier()]):
@@ -160,8 +160,8 @@ def plot_batch_results(df, metric_name, title="", filepath=None, display=True):
     plt.figure(figsize=(6, 6))
     ax = plt.gca()
 
-    y_label = f"Avg {metric_name} (Validation Test)"
-    x_label = f"Avg {metric_name} (Validation Train)"
+    y_label = f"{metric_name} / Validation Test / Mean"
+    x_label = f"{metric_name} / Validation Train / Mean"
     baseline_result = df[df["Model"].str.startswith("Dummy")][y_label].values[0]
 
     sns.scatterplot(data=df, x=x_label, y=y_label, s=100, hue="Model", legend=False)

--- a/src/hundred_hammers/regressor.py
+++ b/src/hundred_hammers/regressor.py
@@ -20,9 +20,9 @@ class HundredHammersRegressor(HundredHammersBase):
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
-    :param n_evals: Number of times to repeat the training of the models (default 10)
+    :param n_cv_evals: Number of times to repeat the training of the models (default 10)
     :param show_progress_bar: Show progress bar in the evaluation (default False)
-    :param seed_cv_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
+    :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     :param seed_train_test: Seed used to split the dataset into train and test (default 0)
     """
 
@@ -36,10 +36,10 @@ class HundredHammersRegressor(HundredHammersBase):
         cross_validator_params={"shuffle": True, "n_splits": 5},
         test_size=0.2,
         n_folds_tune=5,
-        n_evals=10,
+        n_cv_evals=10,
+        n_train_evals=1,
         show_progress_bar=False,
-        seed_cv_strategy="sequential",
-        seed_train_test=0,
+        seed_strategy="sequential",
     ):
         if models is None:
             models = deepcopy(DEFAULT_REGRESSION_MODELS)
@@ -56,8 +56,8 @@ class HundredHammersRegressor(HundredHammersBase):
             cross_validator_params,
             test_size,
             n_folds_tune,
-            n_evals,
+            n_train_evals,
+            n_cv_evals,
             show_progress_bar,
-            seed_cv_strategy,
-            seed_train_test,
+            seed_strategy,
         )

--- a/src/hundred_hammers/regressor.py
+++ b/src/hundred_hammers/regressor.py
@@ -21,7 +21,7 @@ class HundredHammersRegressor(HundredHammersBase):
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
     :param n_train_evals: Number of times to vary the training/test separation seed.
-    :param n_cv_evals: Number of times to vary the cross-validation seed.
+    :param n_val_evals: Number of times to vary the cross-validation seed.
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
@@ -36,7 +36,7 @@ class HundredHammersRegressor(HundredHammersBase):
         cross_validator_params={"shuffle": True, "n_splits": 5},
         test_size=0.2,
         n_folds_tune=5,
-        n_cv_evals=10,
+        n_val_evals=10,
         n_train_evals=1,
         show_progress_bar=False,
         seed_strategy="sequential",
@@ -57,7 +57,7 @@ class HundredHammersRegressor(HundredHammersBase):
             test_size,
             n_folds_tune,
             n_train_evals,
-            n_cv_evals,
+            n_val_evals,
             show_progress_bar,
             seed_strategy,
         )

--- a/src/hundred_hammers/regressor.py
+++ b/src/hundred_hammers/regressor.py
@@ -20,10 +20,10 @@ class HundredHammersRegressor(HundredHammersBase):
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
     :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
-    :param n_cv_evals: Number of times to repeat the training of the models (default 10)
+    :param n_train_evals: Number of times to vary the training/test separation seed.
+    :param n_cv_evals: Number of times to vary the cross-validation seed.
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
-    :param seed_train_test: Seed used to split the dataset into train and test (default 0)
     """
 
     def __init__(

--- a/src/hundred_hammers/regressor.py
+++ b/src/hundred_hammers/regressor.py
@@ -48,16 +48,16 @@ class HundredHammersRegressor(HundredHammersBase):
             metrics = copy(DEFAULT_REGRESSION_METRICS)
 
         super().__init__(
-            models,
-            metrics,
-            eval_metric,
-            input_transform,
-            cross_validator,
-            cross_validator_params,
-            test_size,
-            n_folds_tune,
-            n_train_evals,
-            n_val_evals,
-            show_progress_bar,
-            seed_strategy,
+            models=models,
+            metrics=metrics,
+            eval_metric=eval_metric,
+            input_transform=input_transform,
+            cross_validator=cross_validator,
+            cross_validator_params=cross_validator_params,
+            test_size=test_size,
+            n_train_evals=n_train_evals,
+            n_val_evals=n_val_evals,
+            n_folds_tune=n_folds_tune,
+            show_progress_bar=show_progress_bar,
+            seed_strategy=seed_strategy,
         )

--- a/src/hundred_hammers/regressor.py
+++ b/src/hundred_hammers/regressor.py
@@ -19,9 +19,9 @@ class HundredHammersRegressor(HundredHammersBase):
     :param cross_validator: Cross Validator to use in the evaluation (default KFold)
     :param cross_validator_params: Parameters for the Cross Validator (default {"shuffle": True, "n_splits": 5})
     :param test_size: Percentage of the dataset to use for testing (default 0.2)
-    :param n_folds_tune: Number of Cross Validation folds in grid search (default 5)
     :param n_train_evals: Number of times to vary the training/test separation seed.
     :param n_val_evals: Number of times to vary the cross-validation seed.
+    :param n_folds_tune: Number of Cross Validation folds to use in hyperparameter optimization grid search (default 5)
     :param show_progress_bar: Show progress bar in the evaluation (default False)
     :param seed_strategy: Strategy used to generate the seeds for the different evaluations ('sequential' or 'random')
     """
@@ -35,9 +35,9 @@ class HundredHammersRegressor(HundredHammersBase):
         cross_validator=KFold,
         cross_validator_params={"shuffle": True, "n_splits": 5},
         test_size=0.2,
-        n_folds_tune=5,
-        n_val_evals=10,
+        n_val_evals=1,
         n_train_evals=1,
+        n_folds_tune=5,
         show_progress_bar=False,
         seed_strategy="sequential",
     ):

--- a/test/test_classification.py
+++ b/test/test_classification.py
@@ -59,13 +59,13 @@ def test_seed_strategy():
         ('Dummy', DummyClassifier(), None),
     ]
 
-    df_results_1 = HundredHammersClassifier(models=models, seed_cv_strategy='sequential').evaluate(X, y, optim_hyper=False)
-    df_results_2 = HundredHammersClassifier(models=models, seed_cv_strategy='sequential').evaluate(X, y, optim_hyper=False)
+    df_results_1 = HundredHammersClassifier(models=models, seed_strategy='sequential').evaluate(X, y, optim_hyper=False)
+    df_results_2 = HundredHammersClassifier(models=models, seed_strategy='sequential').evaluate(X, y, optim_hyper=False)
 
     assert df_results_1.equals(df_results_2)
 
-    df_results_3 = HundredHammersClassifier(models=models, seed_cv_strategy='random').evaluate(X, y, optim_hyper=False)
-    df_results_4 = HundredHammersClassifier(models=models, seed_cv_strategy='random').evaluate(X, y, optim_hyper=False)
+    df_results_3 = HundredHammersClassifier(models=models, seed_strategy='random').evaluate(X, y, optim_hyper=False)
+    df_results_4 = HundredHammersClassifier(models=models, seed_strategy='random').evaluate(X, y, optim_hyper=False)
 
     assert not df_results_3.equals(df_results_4)
 


### PR DESCRIPTION
As described in #24, the current version of the library returns the average and standard deviation of train / test performance.; however, since only a single seed is employed, standard deviation for train / test is always 0. To fix this, two approaches were discussed: we could either remove those statistics and define a single train / test split for the whole process (with a seed configurable by the user), or we could allow the end user to determine how many train / test splits they wanted (default being 1), and return the statistics as we do now. Since the second path allows for more flexibility (and therefore is more aligned with the library's ideals), it is the path taken in this pull request.

This pull request allows the user to determine how many times the train / test split will be done, through the newly-added `n_train_evals` parameter. The seed strategy is the one defined by `seed_strategy` (sequential, random, etc). Moreover, we completely refactored the report-creating process, such that now there are two reports:

1. `full_report`: contains the results obtained by each model, training seed, cross-validation seed, and cross-validation fold.
2. `report`: contains the results obtained by each model.

To obtain `report` from `full_report`, we use Pandas methods which make the whole process cleaner.

Finally, the pull request also adds a "How is the data used?" section to the README.md, with a helpful illustration of the new data flow.